### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -56,7 +56,7 @@ class syntax_plugin_bugzillalinks extends DokuWiki_Syntax_Plugin {
 	 * @param Doku_Handler $handler
 	 * @return array
 	 */
-	public function handle($match, $state, $pos, &$handler){
+	public function handle($match, $state, $pos, Doku_Handler $handler){
         if ( preg_match('/^[Bb]ug\s*(\d+)$/', $match, $bugMatch) ) {
 	      return array($match, $bugMatch[1]);
         }
@@ -71,7 +71,7 @@ class syntax_plugin_bugzillalinks extends DokuWiki_Syntax_Plugin {
 	 * @param array $data
 	 * @return boolean
 	 */
-	public function render($mode, &$renderer, $data) {
+	public function render($mode, Doku_Renderer $renderer, $data) {
 		// Only render to xhtml
 		if($mode != 'xhtml') return false;
 


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
